### PR TITLE
다중 이미지 다운로드/보여지는 속도 개선

### DIFF
--- a/KAKAOBANK-SHOH.xcodeproj/project.pbxproj
+++ b/KAKAOBANK-SHOH.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		CB1CE106251519A900508BBF /* SearchResultCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB1CE105251519A900508BBF /* SearchResultCell.swift */; };
 		CB1CE10825151B7000508BBF /* SearchResultCellReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB1CE10725151B7000508BBF /* SearchResultCellReactor.swift */; };
 		CB1CE10A2515210200508BBF /* NetworkManager+UIImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB1CE1092515210200508BBF /* NetworkManager+UIImageView.swift */; };
+		CB397340252210D300AF16C3 /* CompletionWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB39733F252210D300AF16C3 /* CompletionWrapper.swift */; };
 		CB4E285A251EC56100B97DF2 /* ImageCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB4E2859251EC56100B97DF2 /* ImageCacheManager.swift */; };
 		CB7FEB1B2517807500E2ECA4 /* Number+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB7FEB1A2517807500E2ECA4 /* Number+Extensions.swift */; };
 		CB7FEB1D251794B500E2ECA4 /* Date+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB7FEB1C251794B500E2ECA4 /* Date+Extensions.swift */; };
@@ -153,6 +154,7 @@
 		CB1CE105251519A900508BBF /* SearchResultCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultCell.swift; sourceTree = "<group>"; };
 		CB1CE10725151B7000508BBF /* SearchResultCellReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultCellReactor.swift; sourceTree = "<group>"; };
 		CB1CE1092515210200508BBF /* NetworkManager+UIImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NetworkManager+UIImageView.swift"; sourceTree = "<group>"; };
+		CB39733F252210D300AF16C3 /* CompletionWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionWrapper.swift; sourceTree = "<group>"; };
 		CB4E2859251EC56100B97DF2 /* ImageCacheManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheManager.swift; sourceTree = "<group>"; };
 		CB7FEB1A2517807500E2ECA4 /* Number+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Number+Extensions.swift"; sourceTree = "<group>"; };
 		CB7FEB1C251794B500E2ECA4 /* Date+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extensions.swift"; sourceTree = "<group>"; };
@@ -318,6 +320,7 @@
 		CB1CE0BF25147BEB00508BBF /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				CB39733E252210C300AF16C3 /* Wrapper */,
 				CB1CE0C225147C3300508BBF /* Extensions */,
 				CB1CE0C325147C4300508BBF /* Managers */,
 				CB1CE0C425147C5400508BBF /* Protocol */,
@@ -447,6 +450,14 @@
 				CB1CE10125150A6200508BBF /* SearchResultViewReactor.swift */,
 			);
 			path = SearchResult;
+			sourceTree = "<group>";
+		};
+		CB39733E252210C300AF16C3 /* Wrapper */ = {
+			isa = PBXGroup;
+			children = (
+				CB39733F252210D300AF16C3 /* CompletionWrapper.swift */,
+			);
+			path = Wrapper;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -653,6 +664,7 @@
 				CB1CE0F72514C36700508BBF /* HistoryCVCell.swift in Sources */,
 				CB1179E72515BB4C00D9A410 /* SearchDataSouces.swift in Sources */,
 				CB1179E925161CBD00D9A410 /* Reactive+Extensions.swift in Sources */,
+				CB397340252210D300AF16C3 /* CompletionWrapper.swift in Sources */,
 				CB1CE0C125147C2200508BBF /* Cell+Extensions.swift in Sources */,
 				CB1CE0C625147C5B00508BBF /* Reusable.swift in Sources */,
 			);

--- a/KAKAOBANK-SHOH/Utils/Managers/ImageCacheManager.swift
+++ b/KAKAOBANK-SHOH/Utils/Managers/ImageCacheManager.swift
@@ -22,13 +22,17 @@ final class ImageCacheManager {
                                      qos: .utility)
     }
     
-    func getImage(_ key: String) -> UIImage? {
-        return self.cache.object(forKey: key as NSString)
+    func getImage(_ key: String, completion: @escaping ((UIImage?) -> Void)) {
+        ioQueue.async { [weak cache] in
+            let completionWrapper = CompletionWrapper<UIImage?>(completion: completion, defaultValue: nil)
+            let getImage: UIImage? = cache?.object(forKey: key as NSString)
+            completionWrapper.result(getImage)
+        }
     }
     
     func setImage(_ key: String, image: UIImage) {
-        ioQueue.async {
-            self.cache.setObject(image, forKey: key as NSString)
+        ioQueue.async { [weak cache] in
+            cache?.setObject(image, forKey: key as NSString)
         }
     }
 }

--- a/KAKAOBANK-SHOH/Utils/Wrapper/CompletionWrapper.swift
+++ b/KAKAOBANK-SHOH/Utils/Wrapper/CompletionWrapper.swift
@@ -1,0 +1,29 @@
+//
+//  CompletionWrapper.swift
+//  KAKAOBANK-SHOH
+//
+//  Created by Oh Sangho on 2020/09/28.
+//  Copyright © 2020 SH-OH. All rights reserved.
+//
+
+import Foundation
+
+final class CompletionWrapper<Element> {
+    
+    private var completion: ((Element) -> Void)?
+    private let defaultValue: Element
+    
+    init(completion: @escaping ((Element) -> Void), defaultValue: Element) {
+        self.completion = completion
+        self.defaultValue = defaultValue
+    }
+    
+    func result(_ value: Element) {
+        completion?(value)
+        completion = nil
+    }
+    
+    deinit {
+        result(defaultValue)
+    }
+}


### PR DESCRIPTION
1. 1차적으로 cell Reusing으로 단계적으로 보여지는 간단한 이슈는 해결됐지만, 많은 이미지를 가져올 때 느린 현상은 여전함.
- 네트워크의 이미지를 가져올때와 캐싱된 이미지(CacheManager의 getImage)를 동일한 Thread에서 처리하면서 발생한 이슈로 보임..
- Thread를 분리하여 별도로 병렬 수행하도록 처리함. 확실히 개선됨.